### PR TITLE
도메인 설계 및 연관관계 맵핑

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,11 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //mysql
+    implementation 'mysql:mysql-connector-java'
 
     //oauth
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/com/paran/aplay/APlayBackendApplication.java
+++ b/src/main/java/com/paran/aplay/APlayBackendApplication.java
@@ -2,7 +2,9 @@ package com.paran.aplay;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class APlayBackendApplication {
 

--- a/src/main/java/com/paran/aplay/channel/domain/Channel.java
+++ b/src/main/java/com/paran/aplay/channel/domain/Channel.java
@@ -1,0 +1,36 @@
+package com.paran.aplay.channel.domain;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+import com.paran.aplay.common.entity.BaseEntity;
+import com.paran.aplay.team.domain.Team;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "channel")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Channel {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "team_id")
+  private Long id;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "channel_team_id")
+  private Team team;
+}

--- a/src/main/java/com/paran/aplay/channel/domain/Channel.java
+++ b/src/main/java/com/paran/aplay/channel/domain/Channel.java
@@ -1,8 +1,13 @@
 package com.paran.aplay.channel.domain;
 
+import static com.paran.aplay.common.ErrorCode.*;
 import static javax.persistence.GenerationType.IDENTITY;
+import static org.springframework.util.StringUtils.*;
+import static java.util.Objects.*;
 
+import com.paran.aplay.common.ErrorCode;
 import com.paran.aplay.common.entity.BaseEntity;
+import com.paran.aplay.common.error.exception.InvalidRequestException;
 import com.paran.aplay.team.domain.Team;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -24,13 +29,24 @@ public class Channel {
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
-  @Column(name = "team_id")
+  @Column(name = "channel_id")
   private Long id;
 
   @Column(nullable = false, length = 100)
   private String name;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "channel_team_id")
+  @JoinColumn(name = "team_id")
   private Team team;
+
+  public Channel(String name, Team team) {
+    if(!hasText(name)) {
+      throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+    }
+    if(isNull(team)) {
+      throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+    }
+    this.name = name;
+    this.team = team;
+  }
 }

--- a/src/main/java/com/paran/aplay/channel/domain/Channel.java
+++ b/src/main/java/com/paran/aplay/channel/domain/Channel.java
@@ -40,10 +40,10 @@ public class Channel {
   private Team team;
 
   public Channel(String name, Team team) {
-    if(!hasText(name)) {
+    if (!hasText(name)) {
       throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
     }
-    if(isNull(team)) {
+    if (isNull(team)) {
       throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
     }
     this.name = name;

--- a/src/main/java/com/paran/aplay/chat/domain/Chat.java
+++ b/src/main/java/com/paran/aplay/chat/domain/Chat.java
@@ -19,11 +19,11 @@ public class Chat {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "chat_user_id")
+  @JoinColumn(name = "user_id")
   private User writer;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "chat_channel_id")
+  @JoinColumn(name = "channel_id")
   private Channel channel;
 
   @Lob

--- a/src/main/java/com/paran/aplay/chat/domain/Chat.java
+++ b/src/main/java/com/paran/aplay/chat/domain/Chat.java
@@ -17,6 +17,7 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,6 +26,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Chat {
+
   @Id
   @GeneratedValue(strategy = IDENTITY)
   @Column(name = "chat_id")
@@ -41,8 +43,9 @@ public class Chat {
   @Lob
   private String content;
 
+  @Builder
   public Chat(User writer, Channel channel, String content) {
-    if(!hasText(content)) {
+    if (!hasText(content)) {
       throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
     }
     this.writer = writer;

--- a/src/main/java/com/paran/aplay/chat/domain/Chat.java
+++ b/src/main/java/com/paran/aplay/chat/domain/Chat.java
@@ -1,17 +1,29 @@
 package com.paran.aplay.chat.domain;
 
+import static com.paran.aplay.common.ErrorCode.*;
 import static javax.persistence.GenerationType.IDENTITY;
+import static org.springframework.util.StringUtils.*;
 
 import com.paran.aplay.channel.domain.Channel;
+import com.paran.aplay.common.error.exception.InvalidRequestException;
 import com.paran.aplay.user.domain.User;
 import javax.persistence.Column;
+import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Table(name = "chat")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Chat {
   @Id
   @GeneratedValue(strategy = IDENTITY)
@@ -28,4 +40,13 @@ public class Chat {
 
   @Lob
   private String content;
+
+  public Chat(User writer, Channel channel, String content) {
+    if(!hasText(content)) {
+      throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+    }
+    this.writer = writer;
+    this.channel = channel;
+    this.content = content;
+  }
 }

--- a/src/main/java/com/paran/aplay/chat/domain/Chat.java
+++ b/src/main/java/com/paran/aplay/chat/domain/Chat.java
@@ -1,0 +1,31 @@
+package com.paran.aplay.chat.domain;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+import com.paran.aplay.channel.domain.Channel;
+import com.paran.aplay.user.domain.User;
+import javax.persistence.Column;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+
+public class Chat {
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "chat_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chat_user_id")
+  private User writer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chat_channel_id")
+  private Channel channel;
+
+  @Lob
+  private String content;
+}

--- a/src/main/java/com/paran/aplay/common/ApiResponse.java
+++ b/src/main/java/com/paran/aplay/common/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.paran.aplay.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(Include.NON_NULL)
+public class ApiResponse<T> {
+  private String message;
+  private Integer status;
+  private T data;
+
+  @Builder
+  public ApiResponse(String message, Integer status, T data) {
+    this.message = message;
+    this.status = status;
+    this.data = data;
+  }
+}

--- a/src/main/java/com/paran/aplay/common/ApiResponse.java
+++ b/src/main/java/com/paran/aplay/common/ApiResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Getter
 @JsonInclude(Include.NON_NULL)
 public class ApiResponse<T> {
+
   private String message;
   private Integer status;
   private T data;

--- a/src/main/java/com/paran/aplay/common/ErrorCode.java
+++ b/src/main/java/com/paran/aplay/common/ErrorCode.java
@@ -1,0 +1,57 @@
+package com.paran.aplay.common;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+  // Server Error
+  INTERNAL_SERVER_ERROR(500, "S000", "서버에 문제가 생겼습니다."),
+
+  // Client Error
+  METHOD_NOT_ALLOWED(405, "C000", "적절하지 않은 HTTP 메소드입니다."),
+  INVALID_TYPE_VALUE(400, "C001", "요청 값의 타입이 잘못되었습니다."),
+  INVALID_INPUT_VALUE(400, "C002", "적절하지 않은 값입니다."),
+  NOT_FOUND(404, "C003", "해당 리소스를 찾을 수 없습니다."),
+  BAD_REQUEST(400, "C004", "잘못된 요청입니다."),
+  MISSING_REQUEST_PARAMETER(400, "C005", "필수 파라미터가 누락되었습니다."),
+  INVALID_LENGTH(400, "C006", "올바르지 않은 길이입니다."),
+  INVALID_FILE_EXTENSION(400, "C007", "올바르지 않은 파일 확장자입니다. (png, jpg, jpeg 가능)"),
+  MAX_UPLOAD_SIZE_EXCEEDED(400, "C008", "최대 파일 크기(5MB)보다 큰 파일입니다."),
+  RESOURCE_PERMISSION_DENIED(400, "C009", "해당 리소스에 대한 작업 권한이 없습니다."),
+  ACCESS_DENIED(403, "C010", "요청 권한이 없습니다."),
+  UNAUTHENTICATED_USER(401, "C011", "인증되지 않은 사용자입니다."),
+
+  /**
+   * User Domain
+   */
+  USER_NOT_FOUND(400, "U001", "유저가 존재하지 않습니다."),
+  INVALID_ACCOUNT_REQUEST(400, "U002", "아이디 및 비밀번호가 올바르지 않습니다."),
+  INVALID_REFRESH_TOKEN_REQUEST(400, "U003", "토큰이 올바르지 않습니다."),
+  USER_ALREADY_EXISTS(400, "U004", "유저가 이미 존재합니다."),
+  TOKEN_EXPIRED(400, "U005", "토큰이 만료되었습니다."),
+  LOGIN_PARAM_REQUIRED(400, "U006", "로그인 파라미터가 누락되었습니다."),
+  ACCESS_TOKEN_REQUIRED(400, "U007", "access token은 필수입니다."),
+  EMAIL_REQUIRED(400, "U008", "이메일은 필수입니다."),
+  ROLE_NOT_FOUND(400, "U009", "역할이 존재하지 않습니다."),
+  USER_PARAM_REQUIRED(400, "U010", "유저가 누락되었습니다."),
+  USER_PROFILE_NOT_MATCHED(400, "U011", "수정할 프로필 사진이 누락되었으며, 유저의 기존 프로필 이미지와 다른 링크입니다."),
+  NICKNAME_ALREADY_EXISTS(400, "U012", "이미 존재하는 닉네임입니다."),
+  TOKEN_NOT_EXPIRED(400, "U013", "토큰이 아직 만료되지 않았으므로 재발행할 수 없습니다."),
+  PASSWORD_CANNOT_BE_SAME(400, "U014", "새 비밀번호는 이전 비밀번호와 같을 수 없습니다."),
+  REDIS_TOKEN_NOT_FOUND(500, "U015", "유저에 해당하는 토큰을 찾을 수 없습니다."),
+  TOKEN_USER_ID_NOT_MATCHED(400, "U016", "액세스 토큰과 유저 아이디가 매치되지 않습니다."),
+  BLACKLIST_TOKEN_REQUEST(400, "U017", "로그아웃 처리된 토큰으로 요청할 수 없습니다."),
+  OAUTH_PROVIDER_UNSUPPORTED(500, "U018", "아직 지원되지 않은 소셜로그인입니다."),
+
+  OAUTH_EMAIL_REQUIRED(500, "U019", "OAuth email을 수집하는데 실패하였습니다.");
+  private final int status;
+  private final String code;
+  private final String message;
+
+  ErrorCode(int status, String code, String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+}

--- a/src/main/java/com/paran/aplay/common/ErrorResponse.java
+++ b/src/main/java/com/paran/aplay/common/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.paran.aplay.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+
+  private int status;
+  private String code;
+  private String message;
+
+  private ErrorResponse(int status, String code, String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+  public static ErrorResponse of(ErrorCode errorCode) {
+    return new ErrorResponse(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage());
+  }
+
+}

--- a/src/main/java/com/paran/aplay/common/entity/BaseEntity.java
+++ b/src/main/java/com/paran/aplay/common/entity/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.paran.aplay.common.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class BaseEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/paran/aplay/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/paran/aplay/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.paran.aplay.common.error;
+
+import com.paran.aplay.common.ErrorCode;
+import com.paran.aplay.common.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+  // 500 : Internal Server Error
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleServerException(Exception e) {
+    return handleException(e, ErrorCode.INTERNAL_SERVER_ERROR);
+  }
+
+  private ResponseEntity<ErrorResponse> handleException(Exception e, ErrorCode errorCode) {
+    log.warn(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+  }
+}

--- a/src/main/java/com/paran/aplay/common/error/exception/AuthErrorException.java
+++ b/src/main/java/com/paran/aplay/common/error/exception/AuthErrorException.java
@@ -1,0 +1,16 @@
+package com.paran.aplay.common.error.exception;
+
+import com.paran.aplay.common.ErrorCode;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class AuthErrorException extends AuthenticationException {
+
+  private final ErrorCode errorCode;
+
+  public AuthErrorException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/paran/aplay/common/error/exception/InvalidRequestException.java
+++ b/src/main/java/com/paran/aplay/common/error/exception/InvalidRequestException.java
@@ -1,0 +1,14 @@
+package com.paran.aplay.common.error.exception;
+
+import com.paran.aplay.common.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidRequestException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+  public InvalidRequestException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/paran/aplay/document/domain/Document.java
+++ b/src/main/java/com/paran/aplay/document/domain/Document.java
@@ -1,7 +1,12 @@
 package com.paran.aplay.document.domain;
 
+import static com.paran.aplay.common.ErrorCode.*;
+import static org.springframework.util.StringUtils.*;
+
 import com.paran.aplay.channel.domain.Channel;
+import com.paran.aplay.common.ErrorCode;
 import com.paran.aplay.common.entity.BaseEntity;
+import com.paran.aplay.common.error.exception.InvalidRequestException;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -11,11 +16,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.JoinColumns;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -43,4 +48,16 @@ public class Document extends BaseEntity {
 
   @Lob
   private String content;
+
+  @Builder
+  public Document(Channel channel, String title, DocumentType type, String content) {
+    if (!hasText(content) || !hasText(title)) {
+      throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+    }
+
+    this.channel = channel;
+    this.title = title;
+    this.type = type;
+    this.content = content;
+  }
 }

--- a/src/main/java/com/paran/aplay/document/domain/Document.java
+++ b/src/main/java/com/paran/aplay/document/domain/Document.java
@@ -31,7 +31,7 @@ public class Document extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "document_channel_id")
+  @JoinColumn(name = "channel_id")
   private Channel channel;
 
   @Column(nullable = false, length = 100)

--- a/src/main/java/com/paran/aplay/document/domain/Document.java
+++ b/src/main/java/com/paran/aplay/document/domain/Document.java
@@ -1,0 +1,46 @@
+package com.paran.aplay.document.domain;
+
+import com.paran.aplay.channel.domain.Channel;
+import com.paran.aplay.common.entity.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "document")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Document extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "document_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "document_channel_id")
+  private Channel channel;
+
+  @Column(nullable = false, length = 100)
+  private String title;
+
+  @Enumerated(EnumType.STRING)
+  @Column(length = 10)
+  private DocumentType type;
+
+  @Lob
+  private String content;
+}

--- a/src/main/java/com/paran/aplay/document/domain/DocumentType.java
+++ b/src/main/java/com/paran/aplay/document/domain/DocumentType.java
@@ -1,0 +1,6 @@
+package com.paran.aplay.document.domain;
+
+public enum DocumentType {
+  DOCS,
+  BOARD
+}

--- a/src/main/java/com/paran/aplay/document/domain/EventType.java
+++ b/src/main/java/com/paran/aplay/document/domain/EventType.java
@@ -1,0 +1,7 @@
+package com.paran.aplay.document.domain;
+
+public enum EventType {
+  INSERT,
+  UPDATE,
+  DELETE
+}

--- a/src/main/java/com/paran/aplay/document/domain/Operation.java
+++ b/src/main/java/com/paran/aplay/document/domain/Operation.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Operation extends BaseEntity {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "operation_id")

--- a/src/main/java/com/paran/aplay/document/domain/Operation.java
+++ b/src/main/java/com/paran/aplay/document/domain/Operation.java
@@ -1,5 +1,53 @@
 package com.paran.aplay.document.domain;
 
-public class Operation {
+import com.paran.aplay.common.entity.BaseEntity;
+import com.paran.aplay.user.domain.User;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Table(name = "operation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Operation extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "operation_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "document_id")
+  private Document document;
+
+  @Enumerated(EnumType.STRING)
+  @Column(length = 10)
+  private EventType type;
+
+  @Column(length = 2)
+  private String modifiedString;
+
+  @Builder
+  public Operation(User user, Document document, EventType type, String modifiedString) {
+    this.user = user;
+    this.document = document;
+    this.type = type;
+    this.modifiedString = modifiedString;
+  }
 }

--- a/src/main/java/com/paran/aplay/document/domain/Operation.java
+++ b/src/main/java/com/paran/aplay/document/domain/Operation.java
@@ -1,0 +1,5 @@
+package com.paran.aplay.document.domain;
+
+public class Operation {
+
+}

--- a/src/main/java/com/paran/aplay/team/domain/Team.java
+++ b/src/main/java/com/paran/aplay/team/domain/Team.java
@@ -1,6 +1,10 @@
 package com.paran.aplay.team.domain;
 
+import static com.paran.aplay.common.ErrorCode.*;
+import static org.springframework.util.StringUtils.*;
+
 import com.paran.aplay.common.entity.BaseEntity;
+import com.paran.aplay.common.error.exception.InvalidRequestException;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -23,4 +27,10 @@ public class Team extends BaseEntity {
 
   @Column(nullable = false, length = 100)
   private String name;
+
+  public Team(String name) {
+    if(!hasText(name)) {
+      throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+    }
+  }
 }

--- a/src/main/java/com/paran/aplay/team/domain/Team.java
+++ b/src/main/java/com/paran/aplay/team/domain/Team.java
@@ -1,0 +1,26 @@
+package com.paran.aplay.team.domain;
+
+import com.paran.aplay.common.entity.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "team")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Team extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "team_id")
+  private Long id;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+}

--- a/src/main/java/com/paran/aplay/user/domain/AuthProvider.java
+++ b/src/main/java/com/paran/aplay/user/domain/AuthProvider.java
@@ -1,0 +1,7 @@
+package com.paran.aplay.user.domain;
+
+public enum AuthProvider {
+  kakao,
+  google,
+  naver
+}

--- a/src/main/java/com/paran/aplay/user/domain/Authority.java
+++ b/src/main/java/com/paran/aplay/user/domain/Authority.java
@@ -1,0 +1,6 @@
+package com.paran.aplay.user.domain;
+
+public enum Authority {
+  ADMIN,
+  EDITOR
+}

--- a/src/main/java/com/paran/aplay/user/domain/LocalUser.java
+++ b/src/main/java/com/paran/aplay/user/domain/LocalUser.java
@@ -17,7 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Entity
 @DiscriminatorValue("LOCAL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LocalUser extends User{
+public class LocalUser extends User {
 
   private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$";
 

--- a/src/main/java/com/paran/aplay/user/domain/LocalUser.java
+++ b/src/main/java/com/paran/aplay/user/domain/LocalUser.java
@@ -27,8 +27,8 @@ public class LocalUser extends User{
   private String password;
 
   @Builder
-  public LocalUser(String email, String name, String password) {
-    super(email, name);
+  public LocalUser(String email, String name, String password, Authority authority) {
+    super(email, name, authority);
     this.password = password;
   }
 

--- a/src/main/java/com/paran/aplay/user/domain/LocalUser.java
+++ b/src/main/java/com/paran/aplay/user/domain/LocalUser.java
@@ -1,0 +1,54 @@
+package com.paran.aplay.user.domain;
+
+import static com.paran.aplay.common.ErrorCode.*;
+
+import com.paran.aplay.common.error.exception.AuthErrorException;
+import com.paran.aplay.common.error.exception.InvalidRequestException;
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Entity
+@DiscriminatorValue("LOCAL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LocalUser extends User{
+
+  private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$";
+
+  private static final int MAX_PASSWORD_LENGTH = 500;
+
+  @Column(length = MAX_PASSWORD_LENGTH)
+  private String password;
+
+  @Builder
+  public LocalUser(String email, String name, String password) {
+    super(email, name);
+    this.password = password;
+  }
+
+  public void checkPassword(PasswordEncoder passwordEncoder, String credentials) {
+    if (!passwordEncoder.matches(credentials, password)) {
+      throw new AuthErrorException(INVALID_ACCOUNT_REQUEST);
+    }
+  }
+
+  private void validatePassword(String password) {
+    if (password.length() > MAX_PASSWORD_LENGTH) {
+      throw new InvalidRequestException(INVALID_LENGTH);
+    }
+    if (!Pattern.matches(PASSWORD_REGEX, password)) {
+      throw new InvalidRequestException(INVALID_INPUT_VALUE);
+    }
+  }
+
+  public void changePassword(PasswordEncoder passwordEncoder, String password) {
+    validatePassword(password);
+    this.password = passwordEncoder.encode(password);
+  }
+}

--- a/src/main/java/com/paran/aplay/user/domain/OAuthUser.java
+++ b/src/main/java/com/paran/aplay/user/domain/OAuthUser.java
@@ -22,8 +22,8 @@ public class OAuthUser extends User{
   private String providerId;
 
   @Builder
-  public OAuthUser(String email, String name, AuthProvider provider, String providerId) {
-    super(email, name);
+  public OAuthUser(String email, String name, AuthProvider provider, String providerId, Authority authority) {
+    super(email, name, authority);
     this.provider = provider;
     this.providerId = providerId;
   }

--- a/src/main/java/com/paran/aplay/user/domain/OAuthUser.java
+++ b/src/main/java/com/paran/aplay/user/domain/OAuthUser.java
@@ -13,7 +13,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @DiscriminatorValue("OAUTH")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OAuthUser extends User{
+public class OAuthUser extends User {
+
   @Enumerated(EnumType.STRING)
   @Column(name = "provider")
   private AuthProvider provider;
@@ -22,7 +23,8 @@ public class OAuthUser extends User{
   private String providerId;
 
   @Builder
-  public OAuthUser(String email, String name, AuthProvider provider, String providerId, Authority authority) {
+  public OAuthUser(String email, String name, AuthProvider provider, String providerId,
+      Authority authority) {
     super(email, name, authority);
     this.provider = provider;
     this.providerId = providerId;

--- a/src/main/java/com/paran/aplay/user/domain/OAuthUser.java
+++ b/src/main/java/com/paran/aplay/user/domain/OAuthUser.java
@@ -1,0 +1,30 @@
+package com.paran.aplay.user.domain;
+
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("OAUTH")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthUser extends User{
+  @Enumerated(EnumType.STRING)
+  @Column(name = "provider")
+  private AuthProvider provider;
+
+  @Column(name = "provider_id")
+  private String providerId;
+
+  @Builder
+  public OAuthUser(String email, String name, AuthProvider provider, String providerId) {
+    super(email, name);
+    this.provider = provider;
+    this.providerId = providerId;
+  }
+}

--- a/src/main/java/com/paran/aplay/user/domain/User.java
+++ b/src/main/java/com/paran/aplay/user/domain/User.java
@@ -9,6 +9,8 @@ import java.util.regex.Pattern;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -51,7 +53,10 @@ public class User extends BaseEntity {
   @Column(name = "is_quit")
   private Boolean isQuit = false;
 
-  public User(String email, String name) {
+  @Enumerated(EnumType.STRING)
+  private Authority authority = Authority.ADMIN;
+
+  public User(String email, String name, Authority authority) {
     if (!hasText(email)) {
       throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
     }
@@ -62,6 +67,7 @@ public class User extends BaseEntity {
     validateEmail(email);
     validateName(name);
 
+    this.authority = authority;
     this.email = email;
     this.name = name;
   }

--- a/src/main/java/com/paran/aplay/user/domain/User.java
+++ b/src/main/java/com/paran/aplay/user/domain/User.java
@@ -1,0 +1,86 @@
+package com.paran.aplay.user.domain;
+
+import static com.paran.aplay.common.ErrorCode.*;
+import static org.springframework.util.StringUtils.*;
+
+import com.paran.aplay.common.entity.BaseEntity;
+import com.paran.aplay.common.error.exception.InvalidRequestException;
+import java.util.regex.Pattern;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+@Getter
+public class User extends BaseEntity {
+
+  private static final String EMAIL_REGEX = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$";
+
+  private static final String NAME_REGEX = "[a-zA-Z가-힣0-9]+( [a-zA-Z가-힣0-9]+)*";
+  private static final int MAX_EMAIL_LENGTH = 100;
+  private static final int MAX_NAME_LENGTH = 10;
+  private static final int MAX_PROFILEIMAGE_LENGTH = 300;
+
+  @Id
+  @Column(name = "user_id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "email", length = MAX_EMAIL_LENGTH)
+  private String email;
+
+  @Column(name = "profile_image", length = 300)
+  private String profileImage = "";
+
+  @Column(name = "name", nullable = false, length = MAX_NAME_LENGTH)
+  private String name;
+
+  @Column(name = "is_quit")
+  private Boolean isQuit = false;
+
+  public User(String email, String name) {
+    if (!hasText(email)) {
+      throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+    }
+    if (!hasText(name)) {
+      throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+    }
+
+    validateEmail(email);
+    validateName(name);
+
+    this.email = email;
+    this.name = name;
+  }
+
+  private static void validateName(String name) {
+    if (name.length() > MAX_NAME_LENGTH) {
+      throw new InvalidRequestException(INVALID_LENGTH);
+    }
+    if (!Pattern.matches(NAME_REGEX, name)) {
+      throw new InvalidRequestException(INVALID_INPUT_VALUE);
+    }
+  }
+
+  private static void validateEmail(String email) {
+    if (email.length() > MAX_EMAIL_LENGTH) {
+      throw new InvalidRequestException(INVALID_LENGTH);
+    }
+    if (!Pattern.matches(EMAIL_REGEX, email)) {
+      throw new InvalidRequestException(INVALID_INPUT_VALUE);
+    }
+  }
+}

--- a/src/main/java/com/paran/aplay/user/domain/UserChannel.java
+++ b/src/main/java/com/paran/aplay/user/domain/UserChannel.java
@@ -1,0 +1,43 @@
+package com.paran.aplay.user.domain;
+
+import com.paran.aplay.channel.domain.Channel;
+import com.paran.aplay.common.entity.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "user_channel",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "unq_user_channel_user_id_channel_id",
+          columnNames = {"user_id", "channel_id"}
+      )
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserChannel extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_channel_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_channel_user_id")
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_channel_channel_id")
+  private Channel channel;
+}

--- a/src/main/java/com/paran/aplay/user/domain/UserChannel.java
+++ b/src/main/java/com/paran/aplay/user/domain/UserChannel.java
@@ -19,10 +19,10 @@ import lombok.NoArgsConstructor;
 @Table(
     name = "user_channel",
     uniqueConstraints = {
-      @UniqueConstraint(
-          name = "unq_user_channel_user_id_channel_id",
-          columnNames = {"user_id", "channel_id"}
-      )
+        @UniqueConstraint(
+            name = "unq_user_channel_user_id_channel_id",
+            columnNames = {"user_id", "channel_id"}
+        )
     }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,4 +40,9 @@ public class UserChannel extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "channel_id")
   private Channel channel;
+
+  public UserChannel(User user, Channel channel) {
+    this.user = user;
+    this.channel = channel;
+  }
 }

--- a/src/main/java/com/paran/aplay/user/domain/UserChannel.java
+++ b/src/main/java/com/paran/aplay/user/domain/UserChannel.java
@@ -34,10 +34,10 @@ public class UserChannel extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_channel_user_id")
+  @JoinColumn(name = "user_id")
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_channel_channel_id")
+  @JoinColumn(name = "channel_id")
   private Channel channel;
 }

--- a/src/main/java/com/paran/aplay/user/domain/UserTeam.java
+++ b/src/main/java/com/paran/aplay/user/domain/UserTeam.java
@@ -2,7 +2,6 @@ package com.paran.aplay.user.domain;
 
 import static javax.persistence.GenerationType.IDENTITY;
 
-import com.paran.aplay.channel.domain.Channel;
 import com.paran.aplay.common.entity.BaseEntity;
 import com.paran.aplay.team.domain.Team;
 import javax.persistence.Column;
@@ -29,6 +28,7 @@ import lombok.NoArgsConstructor;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserTeam extends BaseEntity {
+
   @Id
   @GeneratedValue(strategy = IDENTITY)
   @Column(name = "user_team_id")
@@ -41,4 +41,9 @@ public class UserTeam extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "team_id")
   private Team team;
+
+  public UserTeam(User user, Team team) {
+    this.user = user;
+    this.team = team;
+  }
 }

--- a/src/main/java/com/paran/aplay/user/domain/UserTeam.java
+++ b/src/main/java/com/paran/aplay/user/domain/UserTeam.java
@@ -1,0 +1,44 @@
+package com.paran.aplay.user.domain;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+import com.paran.aplay.channel.domain.Channel;
+import com.paran.aplay.common.entity.BaseEntity;
+import com.paran.aplay.team.domain.Team;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "user_team",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "unq_user_team_user_id_team_id",
+            columnNames = {"user_id", "team_id"}
+        )
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTeam extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "user_team_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_team_user_id")
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_team_team_id")
+  private Team team;
+}

--- a/src/main/java/com/paran/aplay/user/domain/UserTeam.java
+++ b/src/main/java/com/paran/aplay/user/domain/UserTeam.java
@@ -35,10 +35,10 @@ public class UserTeam extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_team_user_id")
+  @JoinColumn(name = "user_id")
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_team_team_id")
+  @JoinColumn(name = "team_id")
   private Team team;
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,3 @@ spring:
       ddl-auto: update
   jwt:
     client-secret: aplay-local-secret
-  redis:
-    host: localhost
-    port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,17 +4,13 @@ spring:
   profiles:
     include:
       - oauth
-  data:
-    redis:
-      repositories:
-        enabled: false
   jpa:
     open-in-view: false
     properties:
       hibernate:
         default_batch_fetch_size: 1000
   jwt:
-    issuer: backfro
+    issuer: aplay
     accessToken:
       header: accessToken
       expiry-seconds: 1800


### PR DESCRIPTION
## 요약
User, Team, Channel, Chat, Document, Operation 등 서비스에 필요한 도메인들을 설계하고 jpa를 활용한 연관관계 맵핑을 진행함.

## 수정한 내용
<img width="835" alt="image (1)" src="https://user-images.githubusercontent.com/52846807/193450834-661c72c7-921a-4e3a-b9b4-6bcf77435085.png">
연관관계가 잘 맵핑된 모습이다!
