### PR TITLE
채팅 리스너 동작하지 않는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ jib {
     container {
         creationTime = "USE_CURRENT_TIMESTAMP"
         ports=['8080']
-        jvmFlags=["-Dspring.profiles.active=dev", "-Dkms.url=ws://kms-service.aplay.svc.cluster.local:8888"]
+        jvmFlags=["-Dspring.profiles.active=dev", "-Dkms.url=ws://kms-service.aplay.svc.cluster.local:8888/kurento"]
     }
 }
 

--- a/src/main/java/com/paran/aplay/common/config/RedisConfig.java
+++ b/src/main/java/com/paran/aplay/common/config/RedisConfig.java
@@ -1,6 +1,6 @@
 package com.paran.aplay.common.config;
 
-import com.paran.aplay.common.listener.RedisSubscriber;
+import com.paran.aplay.common.listener.ChatSubscriber;
 import lombok.Getter;
 import lombok.Setter;
 import org.slf4j.Logger;
@@ -56,12 +56,12 @@ public class RedisConfig {
   }
 
   @Bean("chatMessageListener")
-  public MessageListenerAdapter chatListenerAdapter(RedisSubscriber subscriber) {
-    return new MessageListenerAdapter(subscriber, "onChatMessage");
+  public MessageListenerAdapter chatListenerAdapter(ChatSubscriber subscriber) {
+    return new MessageListenerAdapter(subscriber, "onMessage");
   }
 
   @Bean("meetingListener")
-  public MessageListenerAdapter meetingListenerAdapter(RedisSubscriber subscriber) {
+  public MessageListenerAdapter meetingListenerAdapter(ChatSubscriber subscriber) {
     return new MessageListenerAdapter(subscriber, "onMeetingMessage");
   }
 

--- a/src/main/java/com/paran/aplay/common/listener/ChatSubscriber.java
+++ b/src/main/java/com/paran/aplay/common/listener/ChatSubscriber.java
@@ -2,27 +2,25 @@ package com.paran.aplay.common.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.paran.aplay.chat.dto.ChatResponse;
-import com.paran.aplay.chat.service.ChatService;
 import com.paran.aplay.common.util.StompMessagingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class RedisSubscriber {
-
+public class ChatSubscriber implements MessageListener{
   private final ObjectMapper objectMapper;
   private final RedisTemplate redisTemplate;
 
   private final StompMessagingService messagingService;
 
-  public void onChatMessage(Message message) {
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
     try{
       String publishedMessage = (String) redisTemplate.getStringSerializer().deserialize(message.getBody());
       ChatResponse chatResponse = objectMapper.readValue(publishedMessage, ChatResponse.class);
@@ -30,9 +28,5 @@ public class RedisSubscriber {
     } catch (Exception e) {
       log.error(e.getMessage());
     }
-  }
-
-  public void onMeetingMessage(Message message) {
-
   }
 }


### PR DESCRIPTION
## 요약
- meeting에서도 redis pub sub 활용할 수 있게끔 MessageListenerAdapter의 default Method Name을 활용하려 했으나 인식하지 않아 기존 MessageListener을 구현하여 onMessage를 사용하는 것으로 변경함.
- kurento media server 연결 url : ws://kms-service.aplay.svc.cluster.local:8888/kurento

