### PR TITLE
문서 API 추가 구현 및 기존 API 수정

### DIFF
--- a/src/main/java/com/paran/aplay/channel/controller/ChannelController.java
+++ b/src/main/java/com/paran/aplay/channel/controller/ChannelController.java
@@ -14,6 +14,7 @@ import com.paran.aplay.chat.service.ChatService;
 import com.paran.aplay.common.ApiResponse;
 import com.paran.aplay.common.PageResponse;
 import com.paran.aplay.common.entity.CurrentUser;
+import com.paran.aplay.document.dto.response.DocumentMetaResponse;
 import com.paran.aplay.document.dto.response.DocumentResponse;
 import com.paran.aplay.document.service.DocumentService;
 import com.paran.aplay.team.domain.Team;
@@ -115,11 +116,11 @@ public class ChannelController {
   }
 
   @GetMapping("/{channelId}/docs")
-  public ResponseEntity<ApiResponse<PageResponse<DocumentResponse>>> getDocuments(@PageableDefault(
+  public ResponseEntity<ApiResponse<PageResponse<DocumentMetaResponse>>> getDocuments(@PageableDefault(
           sort = {"createdAt"},
           direction = Sort.Direction.DESC
   ) Pageable pageable, @PathVariable Long channelId) {
-    PageResponse<DocumentResponse> pageResponse = new PageResponse<>(documentService.getDocuments(channelId, pageable));
+    PageResponse<DocumentMetaResponse> pageResponse = new PageResponse<>(documentService.getDocuments(channelId, pageable));
     ApiResponse apiResponse = ApiResponse.builder()
             .message("문서 다건 조회 성공")
             .status(OK.value())

--- a/src/main/java/com/paran/aplay/document/controller/DocumentController.java
+++ b/src/main/java/com/paran/aplay/document/controller/DocumentController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.OK;
 import com.paran.aplay.common.ApiResponse;
 import com.paran.aplay.document.domain.Document;
 import com.paran.aplay.document.dto.request.DocumentCreateRequest;
+import com.paran.aplay.document.dto.request.DocumentUpdateRequest;
 import com.paran.aplay.document.dto.response.DocumentResponse;
 import com.paran.aplay.document.service.DocumentService;
 import java.net.URI;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,11 +39,26 @@ public class DocumentController {
                 .build();
         return ResponseEntity.created(URI.create("/")).body(apiResponse);
     }
+
     @GetMapping("/{documentId}")
     public ResponseEntity<ApiResponse<DocumentResponse>> getDocument(@PathVariable Long documentId) {
         DocumentResponse documentResponse = DocumentResponse.from(documentService.getDocumentById(documentId));
         ApiResponse apiResponse = ApiResponse.builder()
                 .message("문서 단건 조회")
+                .status(OK.value())
+                .data(documentResponse)
+                .build();
+        return ResponseEntity.ok().body(apiResponse);
+    }
+
+    @PatchMapping("/{documentId}")
+    public ResponseEntity<ApiResponse<DocumentResponse>> updateDocument(@PathVariable Long documentId, @RequestBody
+    DocumentUpdateRequest updateRequest) {
+        Document document = documentService.getDocumentById(documentId);
+        Document updatedDocument = documentService.saveDocument(document, updateRequest);
+        DocumentResponse documentResponse = DocumentResponse.from(updatedDocument);
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("문서 저장 성공")
                 .status(OK.value())
                 .data(documentResponse)
                 .build();

--- a/src/main/java/com/paran/aplay/document/controller/DocumentController.java
+++ b/src/main/java/com/paran/aplay/document/controller/DocumentController.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,4 +47,6 @@ public class DocumentController {
                 .build();
         return ResponseEntity.ok().body(apiResponse);
     }
+
+
 }

--- a/src/main/java/com/paran/aplay/document/controller/DocumentController.java
+++ b/src/main/java/com/paran/aplay/document/controller/DocumentController.java
@@ -65,5 +65,15 @@ public class DocumentController {
         return ResponseEntity.ok().body(apiResponse);
     }
 
+    @DeleteMapping("/{documentId}")
+    public ResponseEntity<ApiResponse> deleteDocument(@PathVariable Long documentId) {
+        Document document = documentService.getDocumentById(documentId);
+        documentService.deleteDocument(document);
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("문서 삭제 성공")
+                .status(OK.value())
+                .build();
+        return ResponseEntity.ok().body(apiResponse);
+    }
 
 }

--- a/src/main/java/com/paran/aplay/document/domain/Document.java
+++ b/src/main/java/com/paran/aplay/document/domain/Document.java
@@ -60,4 +60,12 @@ public class Document extends BaseEntity {
     this.type = type;
     this.content = content;
   }
+
+  public void updateContent(String content) {
+    this.content = content;
+  }
+
+  public void updateTitle(String title) {
+    this.title = title;
+  }
 }

--- a/src/main/java/com/paran/aplay/document/dto/request/DocumentUpdateRequest.java
+++ b/src/main/java/com/paran/aplay/document/dto/request/DocumentUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.paran.aplay.document.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DocumentUpdateRequest {
+
+    @NotBlank
+    private String title;
+
+    private String content;
+}

--- a/src/main/java/com/paran/aplay/document/dto/response/DocumentMetaResponse.java
+++ b/src/main/java/com/paran/aplay/document/dto/response/DocumentMetaResponse.java
@@ -1,0 +1,41 @@
+package com.paran.aplay.document.dto.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.paran.aplay.document.domain.Document;
+import com.paran.aplay.document.domain.DocumentType;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class DocumentMetaResponse {
+
+    private Long documentId;
+
+    private Long channelId;
+
+    private String title;
+
+    private DocumentType type;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    private LocalDateTime createdAt;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    private LocalDateTime updatedAt;
+
+    public static DocumentMetaResponse from(Document document) {
+        return DocumentMetaResponse.builder()
+                .documentId(document.getId())
+                .channelId(document.getChannel().getId())
+                .title(document.getTitle())
+                .type(document.getType())
+                .createdAt(document.getCreatedAt())
+                .updatedAt(document.getUpdatedAt())
+                .build();
+    }
+
+}
+

--- a/src/main/java/com/paran/aplay/document/service/DocumentService.java
+++ b/src/main/java/com/paran/aplay/document/service/DocumentService.java
@@ -8,6 +8,7 @@ import com.paran.aplay.common.ErrorCode;
 import com.paran.aplay.common.error.exception.NotFoundException;
 import com.paran.aplay.document.domain.Document;
 import com.paran.aplay.document.dto.request.DocumentCreateRequest;
+import com.paran.aplay.document.dto.response.DocumentMetaResponse;
 import com.paran.aplay.document.dto.response.DocumentResponse;
 import com.paran.aplay.document.repository.DocumentRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,10 +38,10 @@ public class DocumentService {
         return documentRepository.save(document);
     }
 
-    public Page<DocumentResponse> getDocuments(Long channelId, Pageable pageable) {
+    public Page<DocumentMetaResponse> getDocuments(Long channelId, Pageable pageable) {
         channelUtilService.validateChannelId(channelId);
         Page<Document> documents = documentRepository.findDoucmentsByChannelId(channelId, pageable);
-        return documents.map(DocumentResponse::from);
+        return documents.map(DocumentMetaResponse::from);
     }
 
     public Document getDocumentById(Long documentId) {

--- a/src/main/java/com/paran/aplay/document/service/DocumentService.java
+++ b/src/main/java/com/paran/aplay/document/service/DocumentService.java
@@ -54,4 +54,8 @@ public class DocumentService {
         document.updateTitle(updateRequest.getTitle());
         return documentRepository.save(document);
     }
+
+    public void deleteDocument(Document document) {
+        documentRepository.delete(document);
+    }
 }

--- a/src/main/java/com/paran/aplay/document/service/DocumentService.java
+++ b/src/main/java/com/paran/aplay/document/service/DocumentService.java
@@ -32,6 +32,7 @@ public class DocumentService {
                 .type(createRequest.getType())
                 .channel(channel)
                 .title(createRequest.getTitle())
+                .content("")
                 .build();
         return documentRepository.save(document);
     }

--- a/src/main/java/com/paran/aplay/document/service/DocumentService.java
+++ b/src/main/java/com/paran/aplay/document/service/DocumentService.java
@@ -8,6 +8,7 @@ import com.paran.aplay.common.ErrorCode;
 import com.paran.aplay.common.error.exception.NotFoundException;
 import com.paran.aplay.document.domain.Document;
 import com.paran.aplay.document.dto.request.DocumentCreateRequest;
+import com.paran.aplay.document.dto.request.DocumentUpdateRequest;
 import com.paran.aplay.document.dto.response.DocumentMetaResponse;
 import com.paran.aplay.document.dto.response.DocumentResponse;
 import com.paran.aplay.document.repository.DocumentRepository;
@@ -46,5 +47,11 @@ public class DocumentService {
 
     public Document getDocumentById(Long documentId) {
         return documentRepository.findById(documentId).orElseThrow(() -> new NotFoundException(ErrorCode.DOCUMENT_NOT_FOUND));
+    }
+
+    public Document saveDocument(Document document, DocumentUpdateRequest updateRequest) {
+        document.updateContent(updateRequest.getContent());
+        document.updateTitle(updateRequest.getTitle());
+        return documentRepository.save(document);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,7 +8,7 @@ spring:
         format_sql: true
   datasource:
     driver-class-name: org.h2.Driver
-    url: "jdbc:h2:mem:artzip;MODE=MYSQL;DB_CLOSE_DELAY=-1"
+    url: "jdbc:h2:mem:aplay;MODE=MYSQL;DB_CLOSE_DELAY=-1"
     username: sa
     password:
   jwt:


### PR DESCRIPTION
## 요약
* 문서 저장 API 구현
* 문서 삭제 API 구현

## 수정한 내용
* 문서 다건 조회 API에서 content 정보 제외 (메타 정보만 응답)
* 문서 생성 API에서 content 값을 null 대신 빈 문자열로 채워넣음.

